### PR TITLE
Linux release build without static link system lib

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,16 +3,16 @@ image:
 - Visual Studio 2015
 environment:
   matrix:
-    - architecture: x86_64
+    - ARCHITECTURE: x86_64
       ARCH_NAME: x64
       MSYS2_PATH: C:\msys64\mingw64
-    - architecture: i686
+    - ARCHITECTURE: i686
       ARCH_NAME: x86
       MSYS2_PATH: C:\msys64\mingw32
 install:
   - C:\msys64\usr\bin\bash -lc "pacman -Sy"
-  - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-%architecture%-libpng"
-  - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-%architecture%-jsoncpp"
+  - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-%ARCHITECTURE%-libpng"
+  - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-%ARCHITECTURE%-jsoncpp"
   - curl "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-0.6.0-windows-%ARCH_NAME%.zip" -o libwebp-0.6.0-windows-%ARCH_NAME%.zip 
   - 7z x libwebp-0.6.0-windows-%ARCH_NAME%.zip
   - cp libwebp-0.6.0-windows-%ARCH_NAME%\bin\cwebp.exe %MSYS2_PATH%\bin\

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - brew install webp jsoncpp
     - sudo pip install pytest
   - os: linux
+    dist: trusty
     sudo: required
     language: python
     before_install:

--- a/apng2webp_dependencies/CMakeLists.txt
+++ b/apng2webp_dependencies/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 project(apng2webp_dependecies)
@@ -9,15 +11,15 @@ add_executable(apng2webp_apngopt apng2webp_apngopt/apngopt.cpp)
 add_executable(apngdisraw apngdisraw/apngdis.cpp)
 
 if(STATIC_LINKING)
-    set(BUILD_SHARED_LIBRARIES OFF)
-# OS X gcc or clang -static not work
-    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# Windows MinGW use actually statically linked binary
+    if (MINGW)
         set(CMAKE_EXE_LINKER_FLAGS "-static")
-    endif()
-    set_target_properties(apng2webp_apngopt PROPERTIES LINK_SEARCH_START_STATIC 1)
-    set_target_properties(apng2webp_apngopt PROPERTIES LINK_SEARCH_END_STATIC 1)
-    set_target_properties(apngdisraw PROPERTIES LINK_SEARCH_START_STATIC 1)
-    set_target_properties(apngdisraw PROPERTIES LINK_SEARCH_END_STATIC 1)
+        set_target_properties(apng2webp_apngopt PROPERTIES LINK_SEARCH_START_STATIC ON)
+        set_target_properties(apng2webp_apngopt PROPERTIES LINK_SEARCH_END_STATIC ON)
+        set_target_properties(apngdisraw PROPERTIES LINK_SEARCH_START_STATIC ON)
+        set_target_properties(apngdisraw PROPERTIES LINK_SEARCH_END_STATIC ON)
+    endif(MINGW)
+    set(BUILD_SHARED_LIBRARIES OFF)
 endif(STATIC_LINKING)
 
 if(STATIC_LINKING)


### PR DESCRIPTION
Linux release build without static link system lib, such as libgcc libstdc++ and so on to support some Linux distribution
Cmake add C++11 check because jsoncpp need C++11
travis ci use Ubuntu 14.04 Trusty